### PR TITLE
Windows support for pip installation.

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -70,6 +70,7 @@ def lib():
   global _lib
   if _lib == None:
     _dir = os.path.dirname(os.path.abspath(__file__))
+    _sitepath = os.path.abspath(sys.exec_prefix)
     for ext in ['dll', 'so', 'dylib']:
       try:
         init('libz3.%s' % ext)
@@ -78,6 +79,11 @@ def lib():
         pass
       try:
         init(os.path.join(_dir, 'libz3.%s' % ext))
+        break
+      except:
+        pass
+      try:
+        init(os.path.join(_sitepath, 'lib', 'libz3.%s' % ext))
         break
       except:
         pass

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ build_dir = os.path.abspath(os.path.dirname(__file__))
 
 if sys.platform == 'darwin':
     library_file = "libz3.dylib"
+elif sys.platform == 'win32':
+    library_file = "libz3.dll"
 else:
     library_file = "libz3.so"
 
@@ -20,16 +22,28 @@ else:
 class build(_build):
     @staticmethod
     def _configure():
-        if subprocess.call([ os.path.join(build_dir, 'configure') ],
-                     env=build_env, cwd=build_dir) != 0:
-            raise LibError('Unable to configure Z3.')
+        if sys.platform == 'win32':
+            if subprocess.call([sys.executable, os.path.join(build_dir,
+                                                             'scripts',
+                                                             'mk_make.py')],
+                               env=build_env, cwd=build_dir) != 0:
+                raise LibError("Unable to configure Z3.")
+        else:   # linux and osx
+            if subprocess.call([os.path.join(build_dir, 'configure')],
+                        env=build_env, cwd=build_dir) != 0:
+                raise LibError("Unable to configure Z3.")
 
     @staticmethod
     def _build():
-        if subprocess.call(['make', '-C', os.path.join(build_dir, 'build'),
-                      '-j', str(multiprocessing.cpu_count())],
-                     env=build_env, cwd=build_dir) != 0:
-            raise LibError('Unable to build Z3.')
+        if sys.platform == 'win32':
+            if subprocess.call(['nmake'], env=build_env,
+                               cwd=os.path.join(build_dir, 'build')) != 0:
+                raise LibError("Unable to build Z3.")
+        else:   # linux and osx
+            if subprocess.call(['make', '-C', os.path.join(build_dir, 'build'),
+                                '-j', str(multiprocessing.cpu_count())],
+                        env=build_env, cwd=build_dir) != 0:
+                raise LibError("Unable to build Z3.")
 
     def run(self):
         self.execute(self._configure, (), msg="Configuring Z3")
@@ -41,7 +55,7 @@ except OSError: pass
 
 setup(
     name='angr-z3',
-    version='4.4',
+    version='4.4.0.2',
     description='pip installable distribution of The Z3 Theorem Prover',
     long_description='Z3 is a theorem prover from Microsoft Research. This version is slightly modified by the angr project to enable installation via pip.',
     author="The Z3 Theorem Prover Project",
@@ -61,6 +75,6 @@ setup(
                      'src/api/z3_interp.h', 'src/api/z3_fpa.h',
                      'src/api/c++/z3++.h') )),
     ],
-    scripts=[ os.path.join(build_dir, 'build/z3') ] if sys.version_info[0] == 2 else [ ],
+    scripts=[os.path.join(build_dir, 'build', 'z3')] if sys.version_info[0] == 2 else [],
     cmdclass={'build': build},
 )


### PR DESCRIPTION
- e4d30e0 allows Z3 to be installed via pip on Windows (in a Visual Studio command prompt).
- abd1bfc adds the install dir to the libz3 search path, thus removes the need to call z3.init(<path>) explicitly.

Installation was verified to work (all Python 2.7):
- virtualenv on OS X
- virtualenv on Windows 7
- system-wide on Windows 7

Right now, an error is thrown at the "cleaning up" stage after installation on Windows but the actual installation does work. However, what might not work just yet is installation as a requirement.
