### PR TITLE
Windows support for pip installation.

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -70,6 +70,7 @@ def lib():
   global _lib
   if _lib == None:
     _dir = os.path.dirname(os.path.abspath(__file__))
+    _sitepath = os.path.abspath(sys.exec_prefix)
     for ext in ['dll', 'so', 'dylib']:
       try:
         init('libz3.%s' % ext)
@@ -78,6 +79,11 @@ def lib():
         pass
       try:
         init(os.path.join(_dir, 'libz3.%s' % ext))
+        break
+      except:
+        pass
+      try:
+        init(os.path.join(_sitepath, 'lib', 'libz3.%s' % ext))
         break
       except:
         pass


### PR DESCRIPTION
- f7a3e7 allows Z3 to be installed via pip on Windows (in a Visual Studio command prompt).
- 1cba5de adds the install dir to the libz3 search path, thus removes the need to call z3.init() explicitly.

Installation was verified to work (all Python 2.7):
- virtualenv on OS X
- virtualenv on Windows 7
- system-wide on Windows 7

Right now, an error is thrown at the "cleaning up" stage after installation on Windows but the actual installation does work. However, what might not work just yet is installation as a requirement.e4d30e0 allows Z3 to be installed via pip on Windows (in a Visual Studio command prompt).
