### PR TITLE
Fix for [[clang::fallthrough]]

### DIFF
--- a/src/util/hash.cpp
+++ b/src/util/hash.cpp
@@ -83,8 +83,8 @@ unsigned string_hash(const char * str, unsigned length, unsigned init_value) {
         Z3_fallthrough;
     case 1 : 
         a+=str[0];
-        Z3_fallthrough;
         /* case 0: nothing left to add */
+        break;
     }
     mix(a,b,c);
     /*-------------------------------------------- report the result */


### PR DESCRIPTION
This fixes [the [[clang::fallthrough]] issue](https://github.com/angr/angr-z3/issues/5) and ensures a successful build of angr-z3 on macOS.

This is the same fix introduced upstream in Z3:
https://github.com/Z3Prover/z3/commit/f03f471f025adaed6f82d73b7e19fc8693bbec4f