### PR TITLE
Z3: 4.5.0.post2 -> 4.7.1.post1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import os, sys
+oldplace = os.getcwd()
+place = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'src/api/python')
+os.chdir(place)
+sys.path = [place] + sys.path
+import setup
+os.chdir(oldplace)

--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -118,6 +118,7 @@ def _copy_sources():
     os.mkdir(os.path.join(SRC_DIR_LOCAL, 'src', 'api', 'python'))
     os.mkdir(os.path.join(SRC_DIR_LOCAL, 'src', 'api', 'python', 'z3'))
     open(os.path.join(SRC_DIR_LOCAL, 'src', 'api', 'python', 'z3', '.placeholder'), 'w').close()
+    open(os.path.join(SRC_DIR_LOCAL, 'src', 'api', 'python', 'z3test.py'), 'w').close()
 
 class build(_build):
     def run(self):

--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -172,7 +172,7 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
 
 setup(
     name='z3-solver',
-    version=_z3_version(),
+    version=_z3_version() + '.post1',
     description='an efficient SMT solver library',
     long_description='Z3 is a theorem prover from Microsoft Research with support for bitvectors, booleans, arrays, floating point numbers, strings, and other data types.\n\nFor documentation, please read http://z3prover.github.io/api/html/z3.html\n\nIn the event of technical difficulties related to configuration, compiliation, or installation, please submit issues to https://github.com/angr/angr-z3',
     author="The Z3 Theorem Prover Project",


### PR DESCRIPTION
Updates 2 years old version of z3. Changelog does not list breaking changes: https://github.com/Z3Prover/z3/blob/master/RELEASE_NOTES#L36 - we also did not had any issues upgrading other z3 projects in nixpkgs.
Motivation: Older version does no longer compile with newer versions of gcc.

Maybe you also want to upload a wheel version for python3 this time to fix: https://github.com/angr/angr-z3/issues/7

This pull request is the result of `git rebase` of your old master onto 4.7.1. I only changed the version number here: https://github.com/Mic92/z3/commit/a20a1939168dd933184f01946e5b614deb7dc63e#diff-1523b20a37fbe9727189fa6bd83a0936R175
You can either create a new branch for this or force push my changes.
